### PR TITLE
Propose Red Hat representative to MLOps SIG

### DIFF
--- a/sigs/sig-mlops.md
+++ b/sigs/sig-mlops.md
@@ -25,6 +25,7 @@ The SIG will deliver designs, specifications, shared code and processes that mee
 * Jeremey Lewi (Google) - Kubeflow Lead
 * Andrea Fritolli (IBM) - Tekton Committer
 * Peng Li (IBM) - Tekton Committer
+* Václav Pavlín (Red Hat) - Open Data Hub Lead
 
 ## Communication
 MLOps SIG communication happens via a public mailing list: TBD


### PR DESCRIPTION
Coming late to this exciting initiative, but hopefully not too late.

As we rely on and care about ML Pipelines on Kubernetes in a project I lead (https://opendatahub.io), I'd like to propose an addition of a representative for the MLOps SIG.

We are currently using Argo, but looking into Tekton and Airflow, so we'd hopefully be able to bring some of our experience into the SIG.

@animeshsingh What do you think?
