### PR TITLE
Update link to sig-interoperability repo

### DIFF
--- a/sigs/README.md
+++ b/sigs/README.md
@@ -13,4 +13,4 @@ TOC will identify at least one voting member as TOC Liason for each [proposed SI
 
 * [Security](https://github.com/cdfoundation/sig-security)
 * [MLOps](https://github.com/cdfoundation/sig-mlops)
-* [Interoperability](https://github.com/cdfoundation/sig-Interoperability)
+* [Interoperability](https://github.com/cdfoundation/sig-interoperability)


### PR DESCRIPTION
The repo for SIG Interoperability was initially created as
sig-Interoperability. The repo is renamed to sig-interoperability
in order to be in line with the other SIG repositories.

This commit updates the link to the repo in sigs/README.md.