### PR TITLE
Fix broken hyperlinks in the Project Lifecycle document

### DIFF
--- a/PROJECT_LIFECYCLE.md
+++ b/PROJECT_LIFECYCLE.md
@@ -1,6 +1,6 @@
 ## I. Overview
 
-This governance policy describes how an open source project can formally join the foundation via the [Project Lifecycle Process](). It describes the [Stages]() a project may be admitted under and what the criteria and expectations are for a given stage, as well as the acceptance criteria for a project to move from one stage to another. It also describes the [Annual Review Process]() through which those changes will be evaluated and made. 
+This governance policy describes how an open source project can formally join the foundation via the Project Lifecycle Process defined in this document. It describes the Stages a project may be admitted under and what the criteria and expectations are for a given stage, as well as the acceptance criteria for a project to move from one stage to another. It also describes the Annual Review Process through which those changes will be evaluated and made. 
 
 Project progression - movement from one stage to another - allows projects to participate at the level that is most appropriate for them given where they are in their lifecycle. Regardless of stage, all projects benefit from a deepened alignment with existing projects, and access to mentorship, support, and foundation resources.
 


### PR DESCRIPTION
Likely the links came from another location. Right now they lead to Error 404 if someone clicks them