### PR TITLE
Remove duplication of graduation criteria, update the proposals page

### DIFF
--- a/PROJECT_LIFECYCLE.md
+++ b/PROJECT_LIFECYCLE.md
@@ -11,8 +11,13 @@ This governance policy sets forth the proposal process for projects to be accept
 
 Every project will start at incubation and can progress toward graduation on its own timeline.
 
+### Submitting proposals
+
+Projects must be formally proposed via GitHub by submitting a pull request to this repository.
+See the [Project Proposals](./proposals) directory for the previous proposals and the template.
+
 ### Project Proposal Requirements
-Projects must be formally proposed via GitHub. Project proposals submitted should provide the following information to the best of their ability:
+Project proposals submitted should provide the following information to the best of their ability:
 
 * name of project
 * project description (what it does, why it is valuable, origin and history)
@@ -27,7 +32,7 @@ Projects must be formally proposed via GitHub. Project proposals submitted shoul
 * names of initial committers, if different from those submitting proposal
 * briefly describe the project's leadership team and decision-making process
 * link to any documented governance practices
-* preferred maturity level (see stages below)
+* preferred maturity level (see _Stages_ below)
 * list of project's official communication channels (slack, irc, mailing lists)
 * link to project's website 
 * links to social media accounts

--- a/incubating/README.md
+++ b/incubating/README.md
@@ -1,2 +1,3 @@
 # CDF Incubating Projects
 
+See the list of the CDF projects [here](https://cd.foundation/projects/).

--- a/process/graduation_criteria.md
+++ b/process/graduation_criteria.md
@@ -1,29 +1,5 @@
-# CDF Graduation Criteria v1.0 **[DRAFT]**
+# CDF Graduation Criteria
 
-Every CDF project has an associated maturity level. Proposed CDF projects should state their preferred maturity level. A two-thirds supermajority is required for a project to be accepted as incubating or graduated. If there is not a supermajority of votes to enter as a graduated project, then any graduated votes are recounted as votes to enter as an incubating project. If there is not a supermajority of votes to enter as an incubating project, then any graduated or incubating votes are recounted as sponsorship to enter as an incubating project. If there is not enough sponsorship to enter as an incubating stage project, the project is rejected. This voting process is called fallback voting.
+| WARNING: See the actual information about the project lifecycle and graduation criteria [here](/PROJECT_LIFECYCLE.md) |
+| --- |
 
-Projects of all maturities have access to all resources listed at https://cd.foundation/projects but if there is contention, more mature projects will generally have priority.
-
-## Incubating Stage
-
-Note: The incubation level is the point at which we expect to perform full due diligence on projects.
-
-To be accepted to incubating stage, a project must meet these requirements:
-
- - Document that it is being used successfully in production by at least three independent end users which, in the TOC’s judgement, are of adequate quality and scope.
- - Have a healthy number of committers. A committer is defined as someone with the commit bit; i.e., someone who can accept contributions to some or all of the project.
- - Demonstrate a substantial ongoing flow of commits and merged contributions.
- - Since these metrics can vary significantly depending on the type, scope and size of a project, the TOC has final judgement over the level of activity that is adequate to meet these criteria
- - A clear versioning scheme.
- - Specifications must have at least one public reference implementation.
-
-## Graduation Stage
-
-To graduate from incubating status, or for a new project to join as a graduated project, a project must meet the incubating stage criteria plus:
-
- - Have committers from at least two organizations.
- - Have achieved and maintained a Core Infrastructure Initiative Best Practices Badge.
- - Adopt the CDF Code of Conduct.
- - Explicitly define a project governance and committer process. This preferably is laid out in a GOVERNANCE.md file and references an OWNERS.md file showing the current and emeritus committers.
- - Have a public list of project adopters for at least the primary repo (e.g., ADOPTERS.md or logos on the project website). For a specification, have a list of adopters for the implementation(s) of the spec.
- - Receive a supermajority vote from the TOC to move to graduation stage. Projects can remain in an incubating state indefinitely, but they are normally expected to graduate within two years.

--- a/proposals/README.md
+++ b/proposals/README.md
@@ -5,11 +5,9 @@ Please contribute your project proposal to this folder by adding your proposal v
  - Add entry to the proposals [readme file](README.md)
  - Add your project proposal files to a sub directory in the proposals directory ie cdfoundation/toc/proposals/<proposal_name>
 
-Project Proposal List:
-
- - <project name / link> - proposed_date_MM.DD.YYYY
-
 Project Incubating Approved:
 
  - [Screwdriver](screwdriver/screwdriver.md) - Approved for Incubating 12.17.2019 by TOC
+ - [Ortelius](ortelius/ortelius.md) - Approved for Incubating 08.12.2020 by TOC
+ - [Shipwright](shipwright/shipwright.md) - Approved for Incubating 13.07.2021 by TOC
  


### PR DESCRIPTION
Follow-up to the yesterday's TOC meeting. Cleaning up the confusing duplication as we agreed with the TOC members. CC @sbtaylor15 