### PR TITLE
Remove @tracymiranda from the CDF TOC code owners

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,1 @@
-* @cdfoundation/toc @tracymiranda
+* @cdfoundation/toc


### PR DESCRIPTION
@tracymiranda is no longer with the CDF, and I think there is no need to keep her on the reviewers list.
We could add "TOC Contributors" team and request reviews from them though