### PR TITLE
Update the TOC members

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,15 +18,15 @@ The role of the CDF Technical Oversight Committee (TOC) is to facilitate communi
 
 ## Members
 
-* Dan Lorenc (Tekton, Chainguard) - 1 April 2021 to 31 March 2022  [TOC-appointed]
-* Jithin Emmanuel (Screwdriver, Yahoo) - 1 July 2021 to 30 June 2022 [Elected project seat] 
-* Andrea Frittoli (Tekton, IBM) - 1 July 2021 to 30 June 2022 [Elected project seat]
-* Oleg Nenashev (Jenkins/Keptn, Dynatrace) [Chair] - 1 July 2021 to 30 June 2022 [Elected project seat]
-* Steve Taylor (Ortelius, DeployHub) -  1 July 2021 to 30 June 2022 [Elected project seat]
+* Jithin Emmanuel (Screwdriver, Yahoo) - 1 July 2021 to 30 June 2023 [Elected project seat] 
+* Andrea Frittoli (Tekton, IBM) - 1 July 2021 to 30 June 2023 [Elected project seat]
+* Oleg Nenashev (Jenkins/Keptn, Dynatrace) [Chair] - 1 July 2021 to 30 June 2023 [Elected project seat]
+* Steve Taylor (Ortelius, DeployHub) -  1 July 2021 to 30 June 2023 [Elected project seat]
 * Jason Hall (Tekton/Shipwright, Red Hat) -  1 July 2021 to 30 June 2022 [Elected GB seat]
 * Melissa McKay (JFrog) - 1 July 2021 to 30 June 2022 [Elected GB seat]
-* Garima Bajpai (Ortelius, Canada DevOps Community of Practice ) - 1 July 2021 to 30 June 2022 [GB appointed Ambassador Chair]
-* Fatih Degirmenci (Interoperability SIG, Ericsson) - 1 April 2021 to 31 March 2022 [End-user-appointed]
+* Garima Bajpai (Ortelius, Canada DevOps Community of Practice) - 1 July 2021 to 30 June 2022 [GB appointed Ambassador Chair]
+* Justin Abrams (eBay) - May 1, 2022 to May 1, 2023 [Elected End User Seat]
+* Emil Bäckmark (Ericsson) - May 1, 2022 to May 1, 2023 [Elected End User Seat]
 
 ### TOC Contributors
 
@@ -41,6 +41,8 @@ See the list of TOC Contributors [here](./CONTRIBUTORS.md).
 * Tara Hernandez (Google) - 05/1/2020 to 04/30/2021
 * Yoav Landman (JFrog) - 04/20/2020 to 04/30/2021
 * Andy Glover (Spinnaker) - 03/1/2020 to 08/1/2020
+* Dan Lorenc (Tekton, Chainguard) - 1 April 2021 to 31 March 2022 (TOC-appointed)
+* Fatih Degirmenci (Interoperability SIG, Ericsson) - 1 April 2021 to 31 March 2022 (End-user-appointed)
 
 Updated website for TOC: https://cd.foundation/about/toc/
 


### PR DESCRIPTION
This change updates the TOC list based on the conversation results in the TOC on April 12 [Meeting notes](https://docs.google.com/document/d/1uBHar55fTInWF9Li4t0lyG3tTC8BRLU0FfBfsgk_Jrs/edit#heading=h.ix59vgyev62y) and on the end user seat elections results.

Changes:

- Project elected seat term is extended to two years
- @dlorenc and @fdegir step down from the TOC after the completion of their terms
- @justinabrahms and @e-backmark-ericsson were elected for the End User seats on the TOC. At the moment I keep the 1 year term until the discussion today