### PR TITLE
Update readme with new TOC End User Representatives

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,8 +22,8 @@ The role of the CDF Technical Oversight Committee (TOC) is to facilitate communi
 - Andrea Frittoli, [@afrittoli](https://github.com/afrittoli), (Tekton, IBM) - 1 July 2021 to 30 June 2023 [Elected project seat]
 - Oleg Nenashev, [@oleg-nenashev](https://github.com/oleg-nenashev), (Jenkins/WireMock/OpenFeature, WireMock Inc) - 1 July 2021 to 30 June 2023 [Elected project seat]
 - Steve Taylor, [@sbtaylor15](https://github.com/sbtaylor15), (Ortelius, DeployHub) -  1 July 2021 to 30 June 2023 [Elected project seat]
-- Justin Abrahms, [@justinabrahms](https://github.com/justinabrahms), (eBay) - May 1, 2022 to May 1, 2023 [Elected End User Seat]
-- Emil Bäckmark, [@e-backmark-ericsson](https://github.com/e-backmark-ericsson), (Ericsson) - May 1, 2022 to May 1, 2023 [Elected End User Seat]
+- Dadisi Sanyika, [@dsanyika](https://github.com/dsanyika), (Apple Inc.) - May 1, 2023 to May 1, 2024 [Elected End User Seat]
+- Neil McGonigle, [@McGon-Fid](https://github.com/McGon-Fid), (Fidelity Investments) - May 1, 2023 to May 1, 2024 [Elected End User Seat]
 - Melissa McKay, [@mjmckay](https://github.com/mjmckay), (JFrog) - 1 July 2021 to 01 July 2024 [Elected GB seat]
 - Robert Reeves, [@r2liquibase](https://github.com/r2liquibase),  (Liquibase) - 1 July 2022 to 01 July 2024 [Elected GB seat]
 - Tracy Ragan, [@tracyragan](https://github.com/tracyragan), (Ortelius, DeployHub) - 1 July 2022 to 01 July 2024 [Elected GB seat]
@@ -46,6 +46,8 @@ See the list of TOC Contributors [here](./CONTRIBUTORS.md).
 - Fatih Degirmenci (Interoperability SIG, Ericsson) - 1 April 2021 to 31 March 2022 (End-user-appointed)
 - Garima Bajpai (Ortelius, Canada DevOps Community of Practice) - 1 July 2021 to 30 June 2022 [GB appointed Ambassador Chair]
 - Jason Hall (Tekton/Shipwright, Red Hat) -  1 July 2021 to 30 June 2022 [Elected GB seat]
+- Justin Abrahms (eBay) - 1 May 2022 - 1 May 2023 (Elected End User Seat)
+- Emil Bäckmark (Ericsson) - 1 May 2022 - 1 May 2023 (Elected End User Seat)
 
 Updated website for TOC: <https://cd.foundation/about/toc/>
 


### PR DESCRIPTION
The election for the CDF TOC End User Representatives concluded recently.

https://lists.cd.foundation/g/cdf-toc/message/885

This pull request updates the README.md to include the new end user representatives and moves the previous representatives to alumni.