### PR TITLE
Update TOC Project Representatives and Their Terms

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,10 +19,10 @@ The role of the CDF Technical Oversight Committee (TOC) is to facilitate communi
 
 ## Members
 
-- Jithin Emmanuel, [@jithine](https://github.com/jithine), (Screwdriver, Yahoo) - 1 July 2021 to 30 June 2023 [Elected project seat]
-- Andrea Frittoli, [@afrittoli](https://github.com/afrittoli), (Tekton, IBM) - 1 July 2021 to 30 June 2023 [Elected project seat]
-- Oleg Nenashev, [@oleg-nenashev](https://github.com/oleg-nenashev), (Jenkins/WireMock/OpenFeature, WireMock Inc) - 1 July 2021 to 30 June 2023 [Elected project seat]
-- Steve Taylor, [@sbtaylor15](https://github.com/sbtaylor15), (Ortelius, DeployHub) -  1 July 2021 to 30 June 2023 [Elected project seat]
+- Alan Dong, [@adong](https://github.com/adong), (Screwdriver, Yahoo) - 1 July 2023 to 30 June 2025 [Elected project seat]
+- Andrea Frittoli, [@afrittoli](https://github.com/afrittoli), (Tekton, IBM) - 1 July 2023 to 30 June 2025 [Elected project seat]
+- Mark Waite, [@MarkEWaite](https://github.com/MarkEWaite), (Jenkins, CloudBees) - 1 July 2023 to 30 June 2025 [Elected project seat]
+- Steve Taylor, [@sbtaylor15](https://github.com/sbtaylor15), (Ortelius, DeployHub) -  1 July 2023 to 30 June 2025 [Elected project seat]
 - Dadisi Sanyika, [@dsanyika](https://github.com/dsanyika), (Apple Inc.) - May 1, 2023 to May 1, 2024 [Elected End User Seat]
 - Neil McGonigle, [@McGon-Fid](https://github.com/McGon-Fid), (Fidelity Investments) - May 1, 2023 to May 1, 2024 [Elected End User Seat]
 - Melissa McKay, [@mjmckay](https://github.com/mjmckay), (JFrog) - 1 July 2021 to 01 July 2024 [Elected GB seat]
@@ -49,6 +49,8 @@ See the list of TOC Contributors [here](./CONTRIBUTORS.md).
 - Jason Hall (Tekton/Shipwright, Red Hat) -  1 July 2021 to 30 June 2022 [Elected GB seat]
 - Justin Abrahms (eBay) - 1 May 2022 - 1 May 2023 (Elected End User Seat)
 - Emil Bäckmark (Ericsson) - 1 May 2022 - 1 May 2023 (Elected End User Seat)
+- Jithin Emmanuel (Screwdriver, Yahoo Inc) - 1 July 2021 to 30 June 2023 [Elected project seat]
+- Oleg Nenashev, (Jenkins/WireMock/OpenFeature, WireMock Inc) - 1 July 2021 to 30 June 2023 [Elected project seat]
 
 Updated website for TOC: <https://cd.foundation/about/toc/>
 


### PR DESCRIPTION
The CDF TOC Project Representatives Election concluded on June 28, 2023 and new project representatives elected as well as the terms of the continuing members renewed.

This PR reflects the election results to the README.md file.