### PR TITLE
Add Jenkins 2025 Q1 status report

### DIFF
--- a/projects/jenkins/2025-q1.md
+++ b/projects/jenkins/2025-q1.md
@@ -97,4 +97,4 @@ Jenkins infrastructure cloud costs are spread between multiple donors, including
 * DigitalOcean
 
 Cloud costs are tracked in detail by the Jenkins infrastructure team.
-The year to date expenses are in budget and are planned to remain in budget for the rest of 2024.
+The year to date expenses are in budget and are planned to remain in budget for the rest of 2025.

--- a/projects/jenkins/2025-q1.md
+++ b/projects/jenkins/2025-q1.md
@@ -1,0 +1,100 @@
+# Jenkins Update 2025 Q1
+
+The [Jenkins Contributor Summit](https://community.jenkins.io/t/jenkins-contributor-summit-on-jan-31-2025-call-for-topics-and-ideas/21678/44) was the highlight of the first quarter of 2025.
+
+Over 20 Jenkins contributors gathered in Brussels, Belgium on Friday, January 31, 2025 to review past results and plan for the future of Jenkins.
+Presentations, breakout sessions, and workshops allowed key Jenkins contributors to discuss topics including:
+
+* Jenkins project health and growth
+* Jenkins user experience
+* Jenkins infrastructure
+* Jenkins maintenance
+
+We're deeply grateful to [Beta Cowork](https://www.betacowork.com/) for donating the space to host the Contributor Summit.
+We also thank [Software in the Public Interest](https://www.spi-inc.org/) and [CloudBees, Inc.](https://www.cloudbees.com/) for their funding of travel accommodations for Contributor Summit attendees.
+
+## Features and releases
+
+Jenkins core successfully removed the outdated YahooUI library and its more than 80,000 lines of JavaScript code from Jenkins weekly in January 2025.
+The removal from core was preceded by multiple pull requests and releases of plugins to retain compatibility for Jenkins users.
+
+Jan Faracik and Tim Jacomb of the [User Experience Special Interest Group](https://community.jenkins.io/tag/sig-ux) have been leading the modernization of the Jenkins user interface.
+They have created the [Jenkins Design Library](https://weekly.ci.jenkins.io/design-library/) and have modernized many areas of the Jenkins user interface.
+Jan shared his insights in blog posts, including ["Jenkins Design Library 3"](https://www.jenkins.io/blog/2025/01/10/design-library/), ["A new way to search in Jenkins"](https://www.jenkins.io/blog/2025/02/05/command-palette/) and ["Redsigning Jenkins"](https://www.jenkins.io/blog/2025/03/26/design-post/).
+
+Jenkins continued its pattern of releasing a [new version](https://www.jenkins.io/changelog/) every week and a [new long term support version](https://www.jenkins.io/changelog-stable/) every 4 weeks.
+New features are summarized in the [Jenkins tutorials playlist](https://www.youtube.com/playlist?list=PLvBBnHmZuNQJeznYL2F-MpZYBUeLIXYEe) on [CloudBees TV](https://www.youtube.com/@CloudBeesTV).
+
+## Google Summer of Code 2025
+
+Jenkins has been accepted as a mentoring organization for its ninth year in Google Summer of Code 2025.
+This program fosters new contributors, and is sponsoring five projects including:
+
+* [Jenkins Domain specific LLM based on actual Jenkins usage using ci.jenkins.io data](https://summerofcode.withgoogle.com/programs/2025/projects/oTNbvlrM) - Chirag Gupta
+* [AI-Powered Chatbot for Quick Access to Jenkins Resources](https://summerofcode.withgoogle.com/programs/2025/projects/hVAyeHoe) - Giovanni Vaccarino
+* [Improving Tekton Client Plugin for Jenkins](https://summerofcode.withgoogle.com/programs/2025/projects/NgZbuUAK) - Maeve Ho
+* [Complete build retooling of jenkins.io](https://summerofcode.withgoogle.com/programs/2025/projects/FQsbBQzK) - Birajit Saikia
+* [Improving Plugin Modernizer](https://summerofcode.withgoogle.com/programs/2025/projects/cEtNKcdc) - Raunak Madan
+
+Thanks to the Google Summer of Code organization administrators for Jenkins, [Kris Stern - lead organization administrator](https://www.jenkins.io/blog/authors/krisstern/), [Alyssa Tong](https://www.jenkins.io/blog/authors/alyssat/), and [Bruno Verachten](https://www.jenkins.io/blog/authors/gounthar/).
+
+## Contribution trends
+
+Top contributor retention is tracked in our [contributor statistics repository](https://github.com/jenkins-infra/jenkins-contribution-stats).
+During the quarter we retained our top 30 contributors and added noteworthy new contributors to the top 40 contributor list, including:
+
+* Darin Pope
+* Nikolas Falco
+* Birajit Saikia
+* Yash Pal
+
+The count of individual contributors to Jenkins ranged from 400 to 550 as reported by the [Linux Foundation DevStats project](https://jenkins.devstats.cd.foundation/d/7/companies-contributing-in-repository-groups?orgId=1).
+This is a common pattern that we've seen each year during Google Summer of Code candidate implementation.
+
+## Community updates
+
+The [Jenkins contributor spotlight](https://contributors.jenkins.io/) continues to highlight key Jenkins contributors.
+Spotlights in the first three months of 2025 have included in-depth interviews with:
+
+* [Kohsuke Kawaguchi](https://contributors.jenkins.io/pages/contributors/kohsuke-kawaguchi/) - Creator of Jenkins
+* [Yaroslav Afenkin](https://contributors.jenkins.io/pages/contributors/yaroslav-afenkin/) - Content security policy contributor and former member of Jenkins Security Team
+
+The [Jenkins community site](https://community.jenkins.io/) (donated by Discourse) continues to allow users to help each other.
+
+Several Jenkins special interest groups continue their active development, including:
+
+* [User experience SIG](https://community.jenkins.io/tag/sig-ux)
+* [Platform SIG](https://community.jenkins.io/tag/sig-platform)
+* [Documentation SIG](https://community.jenkins.io/tag/sig-docs)
+* [Infrastructure team](https://community.jenkins.io/tag/sig-infra)
+
+## Governance updates
+
+The Jenkins governance board meets regularly and provides [meeting notes and recordings](https://community.jenkins.io/tag/governance) on the Jenkins community site.
+
+## Security updates
+
+The [Jenkins security team](https://www.jenkins.io/security/) continues to track security issues, report vulnerabilities, and resolve security issues.
+
+Security advisories were published in January and March, including:
+
+* [22 Jan 2025](https://www.jenkins.io/security/advisory/2025-01-22/)
+* [5  Mar 2025](https://www.jenkins.io/security/advisory/2025-03-05/)
+* [19 Mar 2025](https://www.jenkins.io/security/advisory/2025-03-19/)
+
+When reporting a security issue, please follow our [issue reporting guidelines](https://www.jenkins.io/security/reporting/).
+
+## Infrastructure updates
+
+The Jenkins infrastructure team meets weekly and shares the [meeting recordings and meeting notes](https://community.jenkins.io/tag/sig-infra) on the Jenkins community site.
+
+Jenkins infrastructure cloud costs are spread between multiple donors, including:
+
+* Continuous Delivery Foundation
+* CloudBees Inc.
+* Microsoft Azure
+* AWS
+* DigitalOcean
+
+Cloud costs are tracked in detail by the Jenkins infrastructure team.
+The year to date expenses are in budget and are planned to remain in budget for the rest of 2024.


### PR DESCRIPTION
## Add Jenkins 2025 Q1 status report

Key topics included in the update are:

* Contributor Summit
* Features and releases
* Google Summer of Code 2025
* Contribution trends
* Community updates
