### PR TITLE
Add Jenkins 2025 Q2 status report

### DIFF
--- a/projects/jenkins/2025-q2.md
+++ b/projects/jenkins/2025-q2.md
@@ -67,9 +67,10 @@ The [Jenkins security team](https://www.jenkins.io/security/) continues to track
 
 Security advisories were published in January and March, including:
 
-* [22 Jan 2025](https://www.jenkins.io/security/advisory/2025-01-22/)
-* [5  Mar 2025](https://www.jenkins.io/security/advisory/2025-03-05/)
-* [19 Mar 2025](https://www.jenkins.io/security/advisory/2025-03-19/)
+* [2  Apr 2025](https://www.jenkins.io/security/advisory/2025-04-02/)
+* [10 Apr 2025](https://www.jenkins.io/security/advisory/2025-04-10/)
+* [14 May 2025](https://www.jenkins.io/security/advisory/2025-05-14/)
+* [6  Jun 2025](https://www.jenkins.io/security/advisory/2025-06-06/)
 
 When reporting a security issue, please follow our [issue reporting guidelines](https://www.jenkins.io/security/reporting/).
 

--- a/projects/jenkins/2025-q2.md
+++ b/projects/jenkins/2025-q2.md
@@ -1,0 +1,89 @@
+# Jenkins Update 2025 Q2
+
+## Features and releases
+
+Jenkins core successfully removed the outdated YahooUI library and its more than 80,000 lines of JavaScript code from Jenkins in the April 2025 long term support release 2.504.1.
+The removal from core was preceded by multiple pull requests and releases of plugins to retain compatibility for Jenkins users.
+
+Jenkins Pipeline visualization has been significantly improved with recent changes to the [Pipeline Graph View plugin](https://plugins.jenkins.io/pipeline-graph-view/).
+Jan Faracik summarized the key improvements in a [blog post](https://www.jenkins.io/blog/2025/05/02/pipeline-graph-view/).
+
+Navigation improvements for Jenkins have been introduced by Jan Faracik in weekly [2.507](https://www.jenkins.io/changelog/2.507/).
+Jan Faracik and Tim Jacomb of the [User Experience Special Interest Group](https://community.jenkins.io/tag/sig-ux) have been leading the modernization of the Jenkins user interface.
+The navigation improvements are part of the ongoing improvements and will be available in the July 23, 2025 long term support release.
+
+Jenkins continued its pattern of releasing a [new version](https://www.jenkins.io/changelog/) every week and a [new long term support version](https://www.jenkins.io/changelog-stable/) every 4 weeks.
+New features are summarized in the [Jenkins tutorials playlist](https://www.youtube.com/playlist?list=PLvBBnHmZuNQJeznYL2F-MpZYBUeLIXYEe) on [CloudBees TV](https://www.youtube.com/@CloudBeesTV).
+
+## Google Summer of Code 2025
+
+Five projects are now being mentored in the Jenkins project as part of Google Summer of Code 2025.
+The mentored contributors and their projects are:
+
+* [Birajit Saikia](https://www.jenkins.io/blog/2025/06/03/birajit-saikia-gsoc-community-bonding-blog-post/) - [Complete build retooling of jenkins.io](https://summerofcode.withgoogle.com/programs/2025/projects/FQsbBQzK)
+* [Giovanni Vaccarino](https://www.jenkins.io/blog/2025/06/06/giovanni-vaccarino-gsoc-community-bonding-blog-post/) - [AI-Powered Chatbot for Quick Access to Jenkins Resources](https://summerofcode.withgoogle.com/programs/2025/projects/hVAyeHoe)
+* [Maeve Ho](https://www.jenkins.io/blog/2025/06/04/maeve-ho-gsoc-community-bonding-blog-post/) - [Improving Tekton Client Plugin for Jenkins](https://summerofcode.withgoogle.com/programs/2025/projects/NgZbuUAK)
+* [Raunak Madan](https://www.jenkins.io/blog/2025/06/06/raunak-madan-gsoc-community-bonding-blog-post/) - [Improving Plugin Modernizer](https://summerofcode.withgoogle.com/programs/2025/projects/cEtNKcdc)
+* Chirag Gupta - [Jenkins Domain specific LLM based on actual Jenkins usage using ci.jenkins.io data](https://summerofcode.withgoogle.com/programs/2025/projects/oTNbvlrM)
+
+Thanks to Google for sponsoring, funding, and supporting Google Summer of Code 2025.
+Thanks to the Google Summer of Code organization administrators for Jenkins, [Kris Stern - lead organization administrator](https://www.jenkins.io/blog/authors/krisstern/), [Alyssa Tong](https://www.jenkins.io/blog/authors/alyssat/), and [Bruno Verachten](https://www.jenkins.io/blog/authors/gounthar/).
+
+## Contribution trends
+
+Top contributor retention is tracked in our [contributor statistics repository](https://github.com/jenkins-infra/jenkins-contribution-stats).
+During the quarter we retained our top 30 contributors and added noteworthy new contributors to the top 40 contributor list, including:
+
+* Rahul Somasunderam
+* Ivan Fernandez Calvo
+
+The count of individual contributors to Jenkins ranged from 380 to 500 as reported by the [Linux Foundation DevStats project](https://jenkins.devstats.cd.foundation/d/7/companies-contributing-in-repository-groups?orgId=1).
+This is a common pattern that we've seen each year after Google Summer of Code candidate selection is complete.
+
+## Community updates
+
+The [Jenkins contributor spotlight](https://contributors.jenkins.io/) continues to highlight key Jenkins contributors.
+Spotlights in the first three months of 2025 have included in-depth interviews with:
+
+* [Sacha Labourey](https://contributors.jenkins.io/pages/contributors/sacha-labourey/) - CloudBees founder, long-time supporter of Jenkins, former JBoss CTO and board member
+* [Ilan Rabinovitch](https://contributors.jenkins.io/pages/contributors/ilan-rabinovitch/) - Southern Californis Linux Expo founder and long-time open source advocate.
+
+The [Jenkins community site](https://community.jenkins.io/) (donated by Discourse) continues to allow users to help each other.
+
+Several Jenkins special interest groups continue their active development, including:
+
+* [User experience SIG](https://community.jenkins.io/tag/sig-ux)
+* [Platform SIG](https://community.jenkins.io/tag/sig-platform)
+* [Documentation SIG](https://community.jenkins.io/tag/sig-docs)
+* [Infrastructure team](https://community.jenkins.io/tag/sig-infra)
+
+## Governance updates
+
+The Jenkins governance board meets regularly and provides [meeting notes and recordings](https://community.jenkins.io/tag/governance) on the Jenkins community site.
+
+## Security updates
+
+The [Jenkins security team](https://www.jenkins.io/security/) continues to track security issues, report vulnerabilities, and resolve security issues.
+
+Security advisories were published in January and March, including:
+
+* [22 Jan 2025](https://www.jenkins.io/security/advisory/2025-01-22/)
+* [5  Mar 2025](https://www.jenkins.io/security/advisory/2025-03-05/)
+* [19 Mar 2025](https://www.jenkins.io/security/advisory/2025-03-19/)
+
+When reporting a security issue, please follow our [issue reporting guidelines](https://www.jenkins.io/security/reporting/).
+
+## Infrastructure updates
+
+The Jenkins infrastructure team meets weekly and shares the [meeting recordings and meeting notes](https://community.jenkins.io/tag/sig-infra) on the Jenkins community site.
+
+Jenkins infrastructure cloud costs are spread between multiple donors, including:
+
+* Continuous Delivery Foundation
+* CloudBees Inc.
+* Microsoft Azure
+* AWS
+* DigitalOcean
+
+Cloud costs are tracked in detail by the Jenkins infrastructure team.
+The year to date expenses are in budget and are planned to remain in budget for the rest of 2025.

--- a/projects/jenkins/2025-q2.md
+++ b/projects/jenkins/2025-q2.md
@@ -65,7 +65,7 @@ The Jenkins governance board meets regularly and provides [meeting notes and rec
 
 The [Jenkins security team](https://www.jenkins.io/security/) continues to track security issues, report vulnerabilities, and resolve security issues.
 
-Security advisories were published in January and March, including:
+Security advisories were published in April, May, and June, including:
 
 * [2  Apr 2025](https://www.jenkins.io/security/advisory/2025-04-02/)
 * [10 Apr 2025](https://www.jenkins.io/security/advisory/2025-04-10/)


### PR DESCRIPTION
## Add Jenkins 2025 Q2 status report

Key topics include:

* YahooUI removed from Jenkins LTS (80k lines of JavaScript removed, while preserving compatibility)
* UI improvements in Pipeline visualization and in Jenkins page navigation
* Jenkins is running 5 Google Summer of Code projects
* Top contributors are steady, individual contributor counts have decreased (typical after GSoC candidates are selected)
