### PR TITLE
Fix broken link to What's New playlist for Jenkins

### DIFF
--- a/projects/jenkins/2025-q3.md
+++ b/projects/jenkins/2025-q3.md
@@ -17,7 +17,7 @@ LTS releases in Q3 2025:
 * **Jenkins 2.516.3 (September 17)** - Critical security updates and memory leak fixes
 
 Jenkins continued its pattern of releasing a [new version](https://www.jenkins.io/changelog/) every week and a [new long term support version](https://www.jenkins.io/changelog-stable/) every 4 weeks.
-New features in long term support releases are summarized in the ["What's new in Jenkins LTS" playlist]https://www.youtube.com/playlist?list=PLN7ajX_VdyaONWR3E4b4zbjl9rTYf7W_H).
+New features in long term support releases are summarized in the ["What's new in Jenkins LTS" playlist](https://www.youtube.com/playlist?list=PLN7ajX_VdyaONWR3E4b4zbjl9rTYf7W_H).
 Features in older releases are summarized in the  [Jenkins tutorials playlist](https://www.youtube.com/playlist?list=PLvBBnHmZuNQJeznYL2F-MpZYBUeLIXYEe) on [CloudBees TV](https://www.youtube.com/@CloudBeesTV).
 
 ## Google Summer of Code 2025


### PR DESCRIPTION
## Fix broken link to What's New playlist for Jenkins

Link was missing a leading '(' character.

### Before

<img width="952" height="634" alt="before" src="https://github.com/user-attachments/assets/b6b26e26-cebb-4363-baa9-0092fe6cff34" />

### After

<img width="952" height="594" alt="after" src="https://github.com/user-attachments/assets/a209afe2-e583-4f4b-a538-800f29f6b384" />
