### PR TITLE
Add Jenkins 2026 Q1 status report

### DIFF
--- a/projects/jenkins/2026-q1.md
+++ b/projects/jenkins/2026-q1.md
@@ -1,0 +1,105 @@
+# Jenkins Update 2026 Q1
+
+### Jenkins Contributor Summit
+
+Over 20 Jenkins contributors gathered in Brussels, Belgium for the 2026 Jenkins Contributor Summit.
+Stefan Spieker, the Jenkins Events Officer, provided an [experience report](https://www.jenkins.io/blog/2026/03/02/contributor-summit/) and a summary of the officers view of the [present and future of Jenkins](https://www.jenkins.io/blog/2026/03/09/contributor-summit-part-2/).
+
+### Jenkins at FOSDEM
+
+The Jenkins project hosted a table at the Free and Open Source Software Developers' European Meeting ([FOSDEM 2026](https://fosdem.org/)).
+Bruno Verachten, Stefan Merle, and several other members of the Jenkins project were available to greet attendees, answer questions, and encourage contributions.
+Refer to the [announcement](https://www.jenkins.io/blog/2026/01/30/fosdem/) and the [impressions from the Jenkins stand](https://www.jenkins.io/blog/2026/02/16/fosdem-stand-report/).
+
+## Google Summer of Code 2026
+
+Jenkins has been [accepted](https://www.jenkins.io/blog/2026/02/19/jenkins-accepted-as-gsoc-2026-mentoring-org/) as a Google Summer of Code 2026 project.
+Over 300 proposals have been received and are being reviewed.
+Accepted projects will be announced April 30, 2026, with the projects beginning May 1, 2026.
+Special thanks to our organization lead mentor, [Kris Stern](https://www.jenkins.io/blog/authors/krisstern/), and the other Google Summer of Code mentors.
+
+## Features and releases
+
+Notable weekly releases in Q1 2026 included:
+
+* **Jenkins 2.545 (January 5)** - Require Java 21 or newer for the Jenkins controller
+* **Jenkins 2.551 (February 18)** - Security fixes as published in the [security advisory](https://www.jenkins.io/security/advisory/2026-02-18/)
+* **Jenkins 2.552 (February 24)** - Add experimental plugin manager UI
+* **Jenkins 2.554 (March 7)** - Adapt script console for experimental UI
+* **Jenkins 2.555 (March 18)** - Security fixes as published in the [security advisory](https://www.jenkins.io/security/advisory/2026-03-18/)
+* **Jenkins 2.556 (March 25)** - Upgrade to Spring Security 7 and Spring Framework 7
+
+LTS releases in Q1 2026:
+
+* **Jenkins 2.541.1 (January 21)** - Unified RPM repository and updated GPG signing key for RPM and DEB packages
+* **Jenkins 2.541.2 (February 18)** - Security fixes as published in the [security advisory](https://www.jenkins.io/security/advisory/2026-02-18/)
+* **Jenkins 2.541.3 (March 18)** - Security fixes as published in the [security advisory](https://www.jenkins.io/security/advisory/2026-03-18/)
+
+Jenkins continued its pattern of releasing a [new version](https://www.jenkins.io/changelog/) every week and a [new long term support version](https://www.jenkins.io/changelog-stable/) every 4 weeks.
+New features in long term support releases are summarized in the ["What's new in Jenkins LTS" playlist](https://www.youtube.com/playlist?list=PLN7ajX_VdyaONWR3E4b4zbjl9rTYf7W_H).
+
+## Contribution trends
+
+Top contributor retention is tracked in our [contributor statistics repository](https://github.com/jenkins-infra/jenkins-contribution-stats) with reports for [top submitters](https://github.com/jenkins-infra/jenkins-contribution-stats/blob/main/consolidated_data/top_submissions_evolution.md)  and [top commenters](https://github.com/jenkins-infra/jenkins-contribution-stats/blob/main/consolidated_data/top_comments_evolution.md).
+During Q1 2026, we welcomed significant new contributors from our Google Summer of Code applicants.
+
+### Key Q1 2026 Contributor Trends:
+
+**Google Summer of Code Impact:** Q1 2026 was the most active period for new contributors.
+Open pull requests to Jenkins core reached new record highs.
+
+**Contributor Activity:** The count of individual contributors to Jenkins ranged from 300 to 380 as reported by the [Linux Foundation DevStats project](https://jenkins.devstats.cd.foundation/d/7/companies-contributing-in-repository-groups?orgId=1).
+
+### Developer Tools and Ecosystem
+The [Jenkins community site](https://community.jenkins.io/) (donated by Discourse) continues to allow users to help each other.
+
+Several Jenkins special interest groups continue their active development, including:
+
+* [User experience SIG](https://community.jenkins.io/tag/sig-ux)
+* [Platform SIG](https://community.jenkins.io/tag/sig-platform)
+* [Documentation SIG](https://community.jenkins.io/tag/sig-docs)
+* [Infrastructure team](https://community.jenkins.io/tag/sig-infra)
+
+## Governance updates
+
+The Jenkins governance board meets regularly and provides [meeting notes and recordings](https://community.jenkins.io/tag/governance) on the Jenkins community site.
+
+## Security updates
+
+The [Jenkins security team](https://www.jenkins.io/security/) continues to track security issues, report vulnerabilities, and resolve security issues.
+
+Two security advisories were published in Q1 2026:
+
+### [18 February 2026 Security Advisory](https://www.jenkins.io/security/advisory/2026-02-18/)
+
+This advisory addressed multiple plugin vulnerabilities, including:
+* **Stored XSS vulnerability in node offline cause description** (CVE-2026-27099) - Cross-site scripting vulnerability
+* **Build information disclosure vulnerability through Run Parameter** (CVE-2026-27100) - Medium severity information disclosure through Run Parameter
+
+### [18 March 2026 Security Advisory](https://www.jenkins.io/security/advisory/2026-03-18/)
+
+This advisory addressed vulnerabilities in core plugins:
+* **File system information disclosure in Git client Plugin** (CVE-2026-58458) - Medium severity allowing attackers to check file existence on Jenkins controller
+* **SMTP command injection in Jakarta Mail API Plugin** (CVE-2026-7962) - Medium severity allowing arbitrary email contents to be sent
+* **Missing permission checks in global-build-stats Plugin** (CVE-2026-58459) - Medium severity allowing enumeration of graph IDs
+* **Missing permission check in OpenTelemetry Plugin** (CVE-2026-58460) - Medium severity allowing credential capture
+
+When reporting a security issue, please follow our [issue reporting guidelines](https://www.jenkins.io/security/reporting/).
+
+## Infrastructure updates
+
+The Jenkins infrastructure team meets weekly and shares the [meeting recordings and meeting notes](https://community.jenkins.io/tag/sig-infra) on the Jenkins community site.
+
+The Jenkins project has received significant donations from the [GitHub Secure Open Source Fund](https://github.com/open-source/github-secure-open-source-fund) and from the AWS Open Source Credits Program.
+We are profoundly grateful for their contributions and their support of open source software.
+
+Jenkins infrastructure cloud costs are spread between multiple donors, including:
+
+* Continuous Delivery Foundation
+* CloudBees Inc.
+* Microsoft Azure
+* AWS
+* DigitalOcean
+
+Cloud costs are tracked in detail by the Jenkins infrastructure team.
+The year to date expenses are in budget and are planned to remain in budget for the rest of 2026.


### PR DESCRIPTION
## Add Jenkins 2026 Q1 status report

Key topics include:

* Jenkins Contributor Summit 2026
* Jenkins at FOSDEM
* Google Summer of Code 2026
* Donations from GitHub Open Source Fund and AWS Open Source Program
